### PR TITLE
fix on mounted hook in FormWizard

### DIFF
--- a/src/components/FormWizard.vue
+++ b/src/components/FormWizard.vue
@@ -372,6 +372,7 @@
         tabToActivate.active = true
         this.maxStep = this.startIndex
         this.tryChangeRoute(this.tabs[this.startIndex])
+        this.checkStep()
       } else {
         console.warn(`Prop startIndex set to ${this.startIndex} is greater than the number of tabs - ${this.tabs.length}. Make sure that the starting index is less than the number of tabs registered`)
       }


### PR DESCRIPTION
doing a checkStep() if user passed a startIndex prop > 0. 
Fix when user want to start on final step => final button wasn't shown