### PR TITLE
Add explicit button type to button component

### DIFF
--- a/src/components/WizardButton.vue
+++ b/src/components/WizardButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <button class="wizard-btn" tabindex="-1">
+  <button class="wizard-btn" tabindex="-1" type="button">
     <slot></slot>
   </button>
 </template>


### PR DESCRIPTION
Without an explicit type, the button defaults to a submit button if found within a form which can be problematic. Adding type="button" avoids that issue.