### PR TITLE
Add missing type argument

### DIFF
--- a/types/TabContent.ts
+++ b/types/TabContent.ts
@@ -7,7 +7,7 @@ export declare class Tab {
    * Function to execute before tab switch. Return value must be boolean
    * If the return result is false, tab switch is restricted
    */
-  beforeChange (): boolean | Promise
+  beforeChange (): boolean | Promise<boolean>
   /** Vue router route object */
   route: string | object
   additionalInfo: object


### PR DESCRIPTION
Fix typescript compilation error: 

TS2314: Generic type 'Promise<T>' requires 1 type argument(s).