### PR TITLE
Allow user to define the DOM id of the wizard.

### DIFF
--- a/src/components/FormWizard.vue
+++ b/src/components/FormWizard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="vue-form-wizard" :class="[stepSize, {vertical: isVertical}]" @keyup.right="focusNextTab"
+  <div :id="id ? id : ''" class="vue-form-wizard" :class="[stepSize, {vertical: isVertical}]" @keyup.right="focusNextTab"
        @keyup.left="focusPrevTab">
     <div class="wizard-header" v-if="$slots['title']">
       <slot name="title">
@@ -84,6 +84,10 @@
       WizardStep
     },
     props: {
+      id: {
+        type: String,
+        default: 'fw_' + (new Date()).valueOf()
+      },
       title: {
         type: String,
         default: 'Awesome Wizard'


### PR DESCRIPTION
Allow the user to specify the DOM id for the wrapper div of the wizard ([Issue 121](https://github.com/cristijora/vue-form-wizard/issues/121))